### PR TITLE
Makefile: Check out cockpit's bots/ on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-cockpit
+bots


### PR DESCRIPTION
Cockpit's CI already checks out bots/, so no need to do the full
checkout again. But check it out if bots/ does not exist, to keep a
local `make check` working.
    
Also check out the symlinked files from bots/machine, until
https://github.com/cockpit-project/cockpit/pull/8595 lands.

 - [ ] https://github.com/cockpit-project/cockpit/pull/8595 : make it possible to just checkout cockpit's bots/ and use its test VM machinery